### PR TITLE
chore(android): package id → cn.aunly.arkstage + app name 方舟剧场

### DIFF
--- a/docs/android-build.md
+++ b/docs/android-build.md
@@ -66,7 +66,7 @@ until [ "$(adb shell getprop sys.boot_completed | tr -d '\r')" = "1" ]; do sleep
 
 # Install + launch
 adb install -r build/artifacts/app-universal-debug.apk
-adb shell am start -n com.prts.reader/.MainActivity
+adb shell am start -n cn.aunly.arkstage/.MainActivity
 
 # Observe
 adb exec-out screencap -p > /tmp/shot.png
@@ -88,7 +88,7 @@ Enable Developer Options → USB debugging, connect, then:
 
 ```bash
 adb install -r build/artifacts/app-universal-debug.apk
-adb shell am start -n com.prts.reader/.MainActivity
+adb shell am start -n cn.aunly.arkstage/.MainActivity
 ```
 
 ## Storage location
@@ -96,7 +96,7 @@ adb shell am start -n com.prts.reader/.MainActivity
 Data lives in the app-private external files dir:
 
 ```
-/storage/emulated/0/Android/data/com.prts.reader/files/
+/storage/emulated/0/Android/data/cn.aunly.arkstage/files/
   ├── cache/    (story scripts, story index, widget bundle)
   ├── assets/   (engine JS/CSS/font)
   └── media/    (content-addressed CDN media store)
@@ -182,13 +182,13 @@ Android:
   CSS/JS, the four `ui_*.png` toolbar icons, scene art, and audio — all served
   and cached via the handler.
 - **External files dir / JNI:** confirmed. The JNI `getExternalFilesDir(null)`
-  call resolves to `/storage/emulated/0/Android/data/com.prts.reader/files/`, and
+  call resolves to `/storage/emulated/0/Android/data/cn.aunly.arkstage/files/`, and
   all `cache/`, `assets/`, `media/` data lands there. No internal-storage
   fallback was needed.
 - **Asset-protocol scope:** confirmed. The NotoSans font and engine deps load via
   `convertFileSrc()` → `asset://` from the external `assets/engine/` dir with **no**
   "Not allowed to load local resource" / scope-denial errors. The
-  `**/Android/data/com.prts.reader/files/**` scope glob is sufficient.
+  `**/Android/data/cn.aunly.arkstage/files/**` scope glob is sufficient.
 - **Headless-emulator WebView rendering:** works. The home, browser, settings, and
   the engine player (background art + character sprite + dialogue) all render
   under `swiftshader_indirect` — no device fallback required in this environment.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,6 +51,6 @@ Screenshots are written to `/tmp/prts-e2e/` (`01_home` … `05_story_b_loaded`).
 ## Requirements / caveats
 
 - Tools: `Xvfb`, `xdotool`, ImageMagick (`import`, `convert`), `npm`, a built Rust toolchain (`cargo`).
-- `test-e2e.sh` clears `~/.local/share/com.prts.reader/{cache,media,assets}` for a deterministic run.
+- `test-e2e.sh` clears `~/.local/share/cn.aunly.arkstage/{cache,media,assets}` for a deterministic run.
 - **Audio is not tested** — Linux WebKitGTK often lacks mp3/ogg codecs; this verifies the visual pipeline only. Real target platforms (Windows/macOS) ship codecs.
 - UI coordinates assume the window pinned at `0,0` size `1024x600` with no window manager (the script pins this). Override the display with `PRTS_TEST_DISPLAY=:N`.

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -21,7 +21,7 @@ cd "$(dirname "$0")/.."
 
 # ---- config -----------------------------------------------------------------
 DISP="${PRTS_TEST_DISPLAY:-:99}"
-APPID="com.prts.reader"
+APPID="cn.aunly.arkstage"
 APPDATA="${XDG_DATA_HOME:-$HOME/.local/share}/$APPID"
 MEDIA="$APPDATA/media"
 CACHE="$APPDATA/cache"

--- a/src-tauri/gen/android/app/build.gradle.kts
+++ b/src-tauri/gen/android/app/build.gradle.kts
@@ -15,10 +15,10 @@ val tauriProperties = Properties().apply {
 
 android {
     compileSdk = 35
-    namespace = "com.prts.reader"
+    namespace = "cn.aunly.arkstage"
     defaultConfig {
         manifestPlaceholders["usesCleartextTraffic"] = "false"
-        applicationId = "com.prts.reader"
+        applicationId = "cn.aunly.arkstage"
         minSdk = 24
         targetSdk = 35
         versionCode = tauriProperties.getProperty("tauri.android.versionCode", "1").toInt()

--- a/src-tauri/gen/android/app/src/main/java/cn/aunly/arkstage/DownloadService.kt
+++ b/src-tauri/gen/android/app/src/main/java/cn/aunly/arkstage/DownloadService.kt
@@ -1,4 +1,4 @@
-package com.prts.reader
+package cn.aunly.arkstage
 
 import android.app.Notification
 import android.app.NotificationChannel

--- a/src-tauri/gen/android/app/src/main/java/cn/aunly/arkstage/MainActivity.kt
+++ b/src-tauri/gen/android/app/src/main/java/cn/aunly/arkstage/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.prts.reader
+package cn.aunly.arkstage
 
 import android.Manifest
 import android.content.pm.PackageManager

--- a/src-tauri/gen/android/app/src/main/res/values/strings.xml
+++ b/src-tauri/gen/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="app_name">prts-reader</string>
-    <string name="main_activity_title">prts-reader</string>
+    <string name="app_name">方舟剧场</string>
+    <string name="main_activity_title">方舟剧场</string>
 </resources>

--- a/src-tauri/src/android_service.rs
+++ b/src-tauri/src/android_service.rs
@@ -36,7 +36,7 @@ mod imp {
             .l()
             .map_err(|e| e.to_string())?;
         let name = env
-            .new_string("com.prts.reader.DownloadService")
+            .new_string("cn.aunly.arkstage.DownloadService")
             .map_err(|e| e.to_string())?;
         let cls = env
             .call_method(

--- a/src-tauri/src/data_root.rs
+++ b/src-tauri/src/data_root.rs
@@ -209,7 +209,7 @@ pub fn reset_resource_dir() -> Result<ResourceDirInfo, String> {
 }
 
 /// Android: the app-private external files dir
-/// (`/storage/emulated/0/Android/data/com.prts.reader/files`). No runtime
+/// (`/storage/emulated/0/Android/data/cn.aunly.arkstage/files`). No runtime
 /// permission needed; visible to file managers; large quota; cleared on uninstall.
 /// Obtained via JNI `Context.getExternalFilesDir(null)` because Tauri's path
 /// resolver maps `app_data_dir()` to *internal* storage on Android.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Arkstage",
   "version": "0.1.0",
-  "identifier": "com.prts.reader",
+  "identifier": "cn.aunly.arkstage",
   "build": {
     "frontendDist": "../build/dist",
     "devUrl": "http://localhost:5174",
@@ -29,7 +29,7 @@
           "allow": [
             "$APPDATA/**",
             "$APPDATA/../**",
-            "**/Android/data/com.prts.reader/files/**"
+            "**/Android/data/cn.aunly.arkstage/files/**"
           ]
         }
       }


### PR DESCRIPTION
APK `applicationId` and Android app label were still `com.prts.reader` / "prts-reader". Rename the bundle identifier to **`cn.aunly.arkstage`** (from domain aunly.cn) and set the Android display name to **方舟剧场**.

Surgical rename of the committed Android project (CI builds it as-is): gradle namespace/applicationId, Kotlin source dir + package decls/imports, proguard keep-rules, strings.xml, bundled assets config, the Rust JNI class name for the download keep-alive service (`android_service.rs`), tauri.conf identifier + Android data-scope glob, and adb/data-path docs.

⚠️ Identifier is shared, so the desktop bundle id + data dir also move to `cn.aunly.arkstage` (fine pre-release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)